### PR TITLE
proof of concept for tagging directories

### DIFF
--- a/bin/squaretag
+++ b/bin/squaretag
@@ -136,11 +136,12 @@ sub file_iterator {
                     unshift @files,
                       sort map { catfile( $file, $_ ) } @new_files;
                 }
-                next FILE;
+#               next FILE;  # don't skip return $file when -d $file
             }
 
             # TODO handle symlink loops
-            return $file;
+            return $file
+              unless $file eq '.';  # exempt containing dir
         }
         return;
     };
@@ -174,6 +175,7 @@ sub print_tag_list {
 
 sub rename_files {
     my ( $options, $ops ) = @_;
+    @$ops = reverse @$ops;  # allow for renaming directories
     for my $op (@$ops) {
         my ( $old, $new ) = @$op;
         next if $old eq $new;


### PR DESCRIPTION
resolve https://github.com/mdom/squaretag/issues/7#issuecomment-2296160576

IIUIC, hardships come when `squaretag` tries to rename a file when its parent dir has already been renamed, so old pathnames no longer work.

The simplest - and hackiest - solution might be to `reverse @$ops` - reverse array with paths so that renaming goes depth-to-parent instead of parent-to-depth.

This pull request is only to assess the approach, not meant for merging yet.

If `reverse` is OK, more work to be done:
* introduce options for tagging files, directories or both; esp. given that users got used to `squaretag` only working on files
* write tests
* update pod and readme